### PR TITLE
Remove "lists are the most common data structure" phrase

### DIFF
--- a/00-short-introduction-to-Python.md
+++ b/00-short-introduction-to-Python.md
@@ -111,7 +111,7 @@ True
 
 ### Lists
 
-**Lists** are the most common data structure. They can hold a sequence of
+**Lists** are a common data structure to hold a sequence of
 elements. Each element can be accessed by an index:
 
 ```python


### PR DESCRIPTION
I find the statement "lists are the most common data structure" without any qualifications a bit odd.
In particular, in data science, lists should not be used to store your data set. Operations on lists are waaayyy to slow. Data should be stored using pandas or numpy.
I'm not sure if that was meant. If you are thinking about general python, you could argue tuples are more common. However, that is not really relevant to the material here.